### PR TITLE
docs: Add template customization guide in English and Spanish

### DIFF
--- a/docs/website/astro.config.mjs
+++ b/docs/website/astro.config.mjs
@@ -103,6 +103,13 @@ export default defineConfig({
               },
             },
             {
+              label: 'Template Customization',
+              slug: 'guides/customization',
+              translations: {
+                es: 'Personalización de la Plantilla',
+              },
+            },
+            {
               label: 'Release Process',
               slug: 'guides/release',
               translations: {

--- a/docs/website/src/content/docs/en/guides/customization.md
+++ b/docs/website/src/content/docs/en/guides/customization.md
@@ -1,0 +1,68 @@
+---
+title: Template Customization
+---
+
+When you use the **Starter Gradle** template, you likely want to adapt it to your own project and organization. This guide covers the essential steps to make it yours.
+
+## Project Identity
+
+The first step is to rename the project and update its group and version.
+
+### Rename the project
+
+Update the `rootProject.name` in `settings.gradle.kts`:
+
+```kotlin
+rootProject.name = "your-project-name"
+```
+
+### Update group and version
+
+Modify the following properties in `gradle.properties`:
+
+```properties
+GROUP=com.yourcompany
+VERSION=1.0.0-SNAPSHOT
+```
+
+## Maven/POM Metadata
+
+If you plan to publish your project to a Maven repository, you should update the metadata in `gradle.properties`:
+
+```properties
+POM_DEVELOPER_NAME=Your Name
+POM_URL=https://github.com/youruser/your-project
+POM_SCM_CONNECTION=scm:git:https://github.com/youruser/your-project.git
+```
+
+## Package Renaming
+
+The template uses `com.profiletailors` as the base package. You should rename this to match your project's group.
+
+1. Move files in `app/src/main/kotlin/com/profiletailors/app` to your desired package structure.
+2. Update the `package` declaration in all source files.
+3. Repeat for modules in the `examples/` directory if you keep them.
+
+## Documentation Site
+
+The documentation site is built with Starlight. Customize it in `docs/website/astro.config.mjs`:
+
+- `site`: Your production URL.
+- `base`: The subpath if not hosted at the root (e.g., `/your-project`).
+- `starlight.title`: The title of your documentation.
+- `social`: Links to your repository or social media.
+
+## License
+
+The template is licensed under the MIT License.
+
+1. Update the `LICENSE` file with your name/organization and year.
+2. Update `POM_LICENSE_URL` in `gradle.properties` if you change the license.
+
+## CI/CD and GitHub Integration
+
+If you are using GitHub Actions:
+
+1. Review `.github/workflows/` and update any references to `dallay/common-actions` if you wish to use your own shared workflows.
+2. Update `.github/CODEOWNERS` to reflect the maintainers of your project.
+3. Update the `README.md` badges and links.

--- a/docs/website/src/content/docs/es/guides/customization.md
+++ b/docs/website/src/content/docs/es/guides/customization.md
@@ -1,0 +1,68 @@
+---
+title: Personalización de la Plantilla
+---
+
+Cuando utilizas la plantilla **Starter Gradle**, es probable que desees adaptarla a tu propio proyecto y organización. Esta guía cubre los pasos esenciales para hacerla tuya.
+
+## Identidad del proyecto
+
+El primer paso es renombrar el proyecto y actualizar su grupo y versión.
+
+### Renombrar el proyecto
+
+Actualiza `rootProject.name` en `settings.gradle.kts`:
+
+```kotlin
+rootProject.name = "nombre-de-tu-proyecto"
+```
+
+### Actualizar grupo y versión
+
+Modifica las siguientes propiedades en `gradle.properties`:
+
+```properties
+GROUP=com.tuempresa
+VERSION=1.0.0-SNAPSHOT
+```
+
+## Metadatos de Maven/POM
+
+Si planeas publicar tu proyecto en un repositorio Maven, debes actualizar los metadatos en `gradle.properties`:
+
+```properties
+POM_DEVELOPER_NAME=Tu Nombre
+POM_URL=https://github.com/tuusuario/tu-proyecto
+POM_SCM_CONNECTION=scm:git:https://github.com/tuusuario/tu-proyecto.git
+```
+
+## Renombrado de paquetes
+
+La plantilla utiliza `com.profiletailors` como paquete base. Debes renombrarlo para que coincida con el grupo de tu proyecto.
+
+1. Mueve los archivos en `app/src/main/kotlin/com/profiletailors/app` a la estructura de paquetes deseada.
+2. Actualiza la declaración de `package` en todos los archivos fuente.
+3. Repite el proceso para los módulos en el directorio `examples/` si decides conservarlos.
+
+## Sitio de documentación
+
+El sitio de documentación está construido con Starlight. Personalízalo en `docs/website/astro.config.mjs`:
+
+- `site`: Tu URL de producción.
+- `base`: La subruta si no se aloja en la raíz (por ejemplo, `/tu-proyecto`).
+- `starlight.title`: El título de tu documentación.
+- `social`: Enlaces a tu repositorio o redes sociales.
+
+## Licencia
+
+La plantilla está bajo la Licencia MIT.
+
+1. Actualiza el archivo `LICENSE` con tu nombre/organización y el año.
+2. Actualiza `POM_LICENSE_URL` en `gradle.properties` si cambias la licencia.
+
+## CI/CD e integración con GitHub
+
+Si utilizas GitHub Actions:
+
+1. Revisa `.github/workflows/` y actualiza cualquier referencia a `dallay/common-actions` si deseas utilizar tus propios workflows compartidos.
+2. Actualiza `.github/CODEOWNERS` para reflejar los mantenedores de tu proyecto.
+3. Actualiza los badges y enlaces en `README.md`.


### PR DESCRIPTION
This PR adds a new guide to the documentation site (built with Starlight) that explains how to customize the template for individual projects. 

Key areas covered:
- Renaming the project (settings.gradle.kts)
- Updating GROUP and VERSION (gradle.properties)
- Updating Maven/POM metadata
- Renaming packages
- Configuring the documentation site (astro.config.mjs)
- Updating License and CI/CD integration

The documentation is provided in both English and Spanish, following the repository's capitalization conventions.

---
*PR created automatically by Jules for task [2570283290497919122](https://jules.google.com/task/2570283290497919122) started by @yacosta738*