### PR TITLE
fix: Potential fix for code scanning alert no. 4: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/fix-renovate.yml
+++ b/.github/workflows/fix-renovate.yml
@@ -67,12 +67,12 @@ jobs:
           echo "The PR commit is ${{ steps.get-pr-data.outputs.head_sha }}"
           echo "The repository is ${{ steps.get-pr-data.outputs.head_repo }}"
 
-      - name: ✈ Checkout PR branch
+      - name: ✈ Checkout PR commit
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           repository: ${{ steps.get-pr-data.outputs.head_repo }}
-          ref: ${{ steps.get-pr-data.outputs.head_branch }}
+          ref: ${{ steps.get-pr-data.outputs.head_sha }}
 
       - name: 🔍 Verify checked-out commit
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/dallay/starter-gradle/security/code-scanning/4](https://github.com/dallay/starter-gradle/security/code-scanning/4)

In general, to fix an Untrusted Checkout TOCTOU issue in a GitHub Actions workflow, you should ensure that any privileged job that runs code from a pull request checks out that code using an immutable reference (a commit SHA) rather than a mutable reference (branch name or PR ref). That way, even if the attacker pushes new commits to the branch after the security decision (e.g., comment or approval), the workflow will still operate on the reviewed commit. Any subsequent commands (`gradlew`, `npm`, etc.) will then execute only that immutable version of the code.

For this specific workflow, the best fix is to change the `actions/checkout` step at lines 70–76 so that it uses `steps.get-pr-data.outputs.head_sha` as the `ref` instead of `steps.get-pr-data.outputs.head_branch`. The job already has a `🔍 Verify checked-out commit` step that compares `HEAD` to `head_sha`; once we check out directly by SHA, that verification becomes redundant, because `actions/checkout` will either succeed at that commit or fail. We can keep the verification step if desired (for defense in depth), but it is no longer strictly necessary. Importantly, we do not need to change any subsequent steps (`Setup Node`, `Setup Java`, `Setup Gradle`, `writeLocks`, commit and push), because they all operate on the checked-out repository, and by switching to an immutable ref we ensure they run against the trusted commit. No new imports or external actions are required.

Concretely:
- In `.github/workflows/fix-renovate.yml`, locate the “✈ Checkout PR branch” step and change its `ref:` to `${{ steps.get-pr-data.outputs.head_sha }}`.
- Optionally, we can update the step’s name from “Checkout PR branch” to something like “Checkout PR commit” to reflect the new behavior; this does not affect functionality.
- The “🔍 Verify checked-out commit” step can remain as-is; it will now simply confirm that `HEAD` equals the explicitly requested SHA. Removing it would also be safe, but since we’re asked not to change functionality, we’ll keep it.

No other parts of the workflow need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
