### PR TITLE
fix: Renovate configuration regex error

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,7 +85,7 @@
       customType: "regex",
       managerFilePatterns: ["gradle/**/InternalDependencies\\.kt"],
       matchStrings: [
-        '[a-zA-Z0-9_]+\\s*=\\s*\\{(?=[^}]*module\\s*=\\s*"(?<depName>[^" ]+)")(?=[^}]*version\\s*=\\s*"(?<currentValue>[^" ]+)")(?=[^}]*type\\s*=\\s*"(?<datasource>[^" ]+)")[^}]*\\}',
+        '[a-zA-Z0-9_]+\\s*=\\s*\\{\\s*module\\s*=\\s*"(?<depName>[^" ]+)"\\s*,\\s*version\\s*=\\s*"(?<currentValue>[^" ]+)"\\s*,\\s*type\\s*=\\s*"(?<datasource>[^" ]+)"[^}]*\\}',
       ],
     },
   ],


### PR DESCRIPTION
Fixed the Renovate configuration error by replacing a regex that used lookahead assertions (unsupported by Renovate's RE2 engine) with a sequential matching regex. Verified the fix using `renovate-config-validator`.

Fixes #28

---
*PR created automatically by Jules for task [3927170049424627035](https://jules.google.com/task/3927170049424627035) started by @yacosta738*