### PR TITLE
ci: standardize workflows using common-actions v2.0.0

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,12 @@
+name: Auto-merge dependencies
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-merge:
+    uses: dallay/common-actions/.github/workflows/dependabot-auto-merge.yml@v2.0.0
+    with:
+      target: squash
+      approve: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,13 +1,7 @@
-name: Lint PR title
-
+name: Semantic PR
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
-
-permissions:
-  pull-requests: write
-
 jobs:
-  lint:
-    uses: dallay/common-actions/.github/workflows/semantic-pr.yml@main
-    secrets: inherit
+  main:
+    uses: dallay/common-actions/.github/workflows/semantic-pull-request.yml@v2.0.0


### PR DESCRIPTION
## 🎯 Objetivo

Estandarizar workflows de CI/CD usando flujos reutilizables desde `dallay/common-actions@v2.0.0`.

## 📋 Cambios

- ✅ Validación de títulos de PR (Semantic PR)
- ✅ Auto-merge de PRs de dependencias (Dependabot/Renovate)

## 🔗 Relacionado

- Issue dallay/agentsync#430
- PR base: dallay/common-actions#48